### PR TITLE
fix content-list/books.md to be a proper list

### DIFF
--- a/content-list/books.md
+++ b/content-list/books.md
@@ -1,5 +1,5 @@
 # Books to Read
 
-[ ] [Eloquent Javascript](http://eloquentjavascript.net/)
-[ ] [Pocket Guide to Writing SVG](http://svgpocketguide.com/book/)s
-[ ] That Book That I Have a Physical Copy of Counts, Too
+- [ ] [Eloquent Javascript](http://eloquentjavascript.net/)
+- [ ] [Pocket Guide to Writing SVG](http://svgpocketguide.com/book/)s
+- [ ] That Book That I Have a Physical Copy of Counts, Too


### PR DESCRIPTION
Hi!
Noticed that books.md in the content-list folder was missing a '-' character which caused it to not be a list. Pretty simple really :smile: 
